### PR TITLE
add support for globs and a configurable delimiter

### DIFF
--- a/bin/source-map-concat
+++ b/bin/source-map-concat
@@ -57,38 +57,38 @@ program.args.forEach(function (f) {
             code: fs.readFileSync(f).toString()
         });
     }
-
-    files.forEach(function (file) {
-        var previousMap = resolveSourceMapSync(file.code, file.source, fs.readFileSync);
-        if (previousMap) {
-            file.map = previousMap.map;
-            file.sourcesRelativeTo = previousMap.sourcesRelativeTo;
-            file.code = file.code.replace(sourceMapRe, '');
-        } else {
-            file.map = createDummySourceMap(file.code, {
-                source: path.basename(file.source),
-                type: "js"
-            });
-            file.sourcesRelativeTo = file.source;
-        }
-    });
-
-    var mapPath = output + ".map";
-
-    if (program.output_dir) {
-        mapPath = path.join(program.output_dir, path.basename(output) + ".map");
-    }
-
-    // Wrap this is a JSON.parse so it interprets \n, \t, etc.
-    var concatenated = concat(files, {
-        delimiter: JSON.parse('"' + program.delimiter + '"'),
-        mapPath: mapPath
-    });
-
-    var result = concatenated.toStringWithSourceMap({
-        file: path.basename(output)
-    });
-
-    fs.writeFileSync(output, result.code);
-    fs.writeFileSync(output + ".map", result.map.toString());
 });
+
+files.forEach(function (file) {
+    var previousMap = resolveSourceMapSync(file.code, file.source, fs.readFileSync);
+    if (previousMap) {
+        file.map = previousMap.map;
+        file.sourcesRelativeTo = previousMap.sourcesRelativeTo;
+        file.code = file.code.replace(sourceMapRe, '');
+    } else {
+        file.map = createDummySourceMap(file.code, {
+            source: path.basename(file.source),
+            type: "js"
+        });
+        file.sourcesRelativeTo = file.source;
+    }
+});
+
+var mapPath = output + ".map";
+
+if (program.output_dir) {
+    mapPath = path.join(program.output_dir, path.basename(output) + ".map");
+}
+
+// Wrap this is a JSON.parse so it interprets \n, \t, etc.
+var concatenated = concat(files, {
+    delimiter: JSON.parse('"' + program.delimiter + '"'),
+    mapPath: mapPath
+});
+
+var result = concatenated.toStringWithSourceMap({
+    file: path.basename(output)
+});
+
+fs.writeFileSync(output, result.code);
+fs.writeFileSync(output + ".map", result.map.toString());

--- a/bin/source-map-concat
+++ b/bin/source-map-concat
@@ -25,7 +25,7 @@ program
     .usage('<file ...>')
     .option('-o, --output <outfile>', 'Output file')
     .option('-d, --output_dir [output_dir]', "Final output directory, if different than output file's")
-    .option('-l --delimiter <string>', 'Delimiter', '"\\n"')
+    .option('-l, --delimiter <string>', 'Delimiter', '\\n')
     .parse(process.argv);
 
 if (!program.args.length) {

--- a/bin/source-map-concat
+++ b/bin/source-map-concat
@@ -4,26 +4,28 @@ var path = require('path'),
     fs = require('fs'),
     program = require('commander'),
     concat = require('source-map-concat'),
+    glob = require('glob'),
     resolveSourceMapSync = require("source-map-resolve").resolveSourceMapSync,
     createDummySourceMap = require("source-map-dummy"),
     sourceMapReInner = "[#@] sourceMappingURL=([^\\s'\"]*)",
     sourceMapRe = new RegExp([
-      "(?:",
-       "/\\*",
-       "(?:\\s*\\r?\\n(?://)?)?",
-       "(?:" + sourceMapReInner + ")",
-       "\\s*",
-       "\\*/",
-       "|",
-       "//(?:" + sourceMapReInner + ")",
-      ")",
-      "\\s*$"].join(""), 'g');
+        "(?:",
+        "/\\*",
+        "(?:\\s*\\r?\\n(?://)?)?",
+        "(?:" + sourceMapReInner + ")",
+        "\\s*",
+        "\\*/",
+        "|",
+        "//(?:" + sourceMapReInner + ")",
+        ")",
+        "\\s*$"].join(""), 'g');
 
 program
     .version('1.0.0')
     .usage('<file ...>')
     .option('-o, --output <outfile>', 'Output file')
     .option('-d, --output_dir [output_dir]', "Final output directory, if different than output file's")
+    .option('-l --delimiter <string>', 'Delimiter', '"\\n"')
     .parse(process.argv);
 
 if (!program.args.length) {
@@ -35,45 +37,58 @@ var files = [];
 
 var output = path.resolve(program.output);
 
-program.args.forEach(function(f) {
-    if (!fs.statSync(f).isFile()) {
-        throw new Error("File is not a file: " + f);
-    }
-    files.push({
-        source: path.resolve(f),
-        code: fs.readFileSync(f).toString()
-    });
-});
+program.args.forEach(function (f) {
 
-files.forEach(function(file) {
-    var previousMap = resolveSourceMapSync(file.code, file.source, fs.readFileSync);
-    if (previousMap) {
-        file.map = previousMap.map;
-        file.sourcesRelativeTo = previousMap.sourcesRelativeTo;
-        file.code = file.code.replace(sourceMapRe, '');
-    } else {
-        file.map = createDummySourceMap(file.code, {
-            source: path.basename(file.source),
-            type: "js"
+    if (glob.hasMagic(f)) {
+        var matches = glob.sync(f);
+        matches.forEach(function (element) {
+            files.push({
+                source: path.resolve(element),
+                code: fs.readFileSync(element).toString()
+            });
         });
-        file.sourcesRelativeTo = file.source;
     }
+    else if (!fs.statSync(f).isFile()) {
+        throw new Error("Argument is neither a glob nor a file: " + f);
+    }
+    else {
+        files.push({
+            source: path.resolve(f),
+            code: fs.readFileSync(f).toString()
+        });
+    }
+
+    files.forEach(function (file) {
+        var previousMap = resolveSourceMapSync(file.code, file.source, fs.readFileSync);
+        if (previousMap) {
+            file.map = previousMap.map;
+            file.sourcesRelativeTo = previousMap.sourcesRelativeTo;
+            file.code = file.code.replace(sourceMapRe, '');
+        } else {
+            file.map = createDummySourceMap(file.code, {
+                source: path.basename(file.source),
+                type: "js"
+            });
+            file.sourcesRelativeTo = file.source;
+        }
+    });
+
+    var mapPath = output + ".map";
+
+    if (program.output_dir) {
+        mapPath = path.join(program.output_dir, path.basename(output) + ".map");
+    }
+
+    // Wrap this is a JSON.parse so it interprets \n, \t, etc.
+    var concatenated = concat(files, {
+        delimiter: JSON.parse('"' + program.delimiter + '"'),
+        mapPath: mapPath
+    });
+
+    var result = concatenated.toStringWithSourceMap({
+        file: path.basename(output)
+    });
+
+    fs.writeFileSync(output, result.code);
+    fs.writeFileSync(output + ".map", result.map.toString());
 });
-
-var mapPath = output + ".map";
-
-if (program.output_dir) {
-    mapPath = path.join(program.output_dir, path.basename(output) + ".map");
-}
-
-var concatenated = concat(files, {
-    delimiter: "\n",
-    mapPath: mapPath
-});
-
-var result = concatenated.toStringWithSourceMap({
-    file: path.basename(output)
-});
-
-fs.writeFileSync(output, result.code);
-fs.writeFileSync(output + ".map", result.map.toString());

--- a/package.json
+++ b/package.json
@@ -17,10 +17,13 @@
     "concatenate",
     "concat",
     "cat",
-    "mapcat"
+    "mapcat",
+    "glob",
+    "globbing"
   ],
   "dependencies": {
     "commander": "^2.9.0",
+    "glob": "^7.1.2",
     "source-map": "^0.5.3",
     "source-map-concat": "^1.0.0",
     "source-map-dummy": "^1.0.0",


### PR DESCRIPTION
I couldn't find a package that could do sourcemaps AND supported globs. Your package seemed to do nearly everything I wanted and was easy to understand to add this functionality in.

While there, I also had a nice-to-have of making the delimiter configurable, so I added that to (you could separate with semi-colon, or semi-colon + newline, etc).

Would you please consider adding this in?